### PR TITLE
Remove Python 3.7 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "3.5"
   - "3.6"
-  - "3.7"
 sudo: false
 services:
     - docker


### PR DESCRIPTION
...while Travis CI project sorts out the issues.

https://github.com/travis-ci/travis-ci/issues/9552