### PR TITLE
Added response and function for fetching team status

### DIFF
--- a/plugins/pco/pcoservices.py
+++ b/plugins/pco/pcoservices.py
@@ -67,6 +67,17 @@ class PcoServicesPlugin(WillPlugin):
         else:
             self.say("", message=message, attachments=attachment, channel=wl_chan_id(self))
 
+    @respond_to("(who is scheduled on the )(?P<pco_team>[\w\s]+) team (?P<pco_date>.*?(?=(?:\'|\?)|$))\??")
+    def pco_team_schedule_lookup(self, message, pco_team, pco_date):
+        """Lookup a [team] and display its confirmed and unconfirmed members for a given date"""
+        pco_team = pco_team.strip()
+        self.reply("Hold on; I'll look up that team's schedule for you.")
+        attachments = teams.get_for_date(pco_team, pco_date)
+        attachment = []
+        for returned_attachment in attachments:
+            attachment += returned_attachment.slack()
+        self.say("", message=message, attachments=attachment, channel=wl_chan_id(self))
+
 
 # Test your setup by running this file.
 # If you add functions in this file please add a test below.

--- a/plugins/pco/teams.py
+++ b/plugins/pco/teams.py
@@ -1,10 +1,62 @@
 import pypco
 import os
+import parsedatetime
+from datetime import datetime
 from plugins.pco import msg_attachment
-
+import pytz
 
 pco = pypco.PCO(os.environ["WILL_PCO_APPLICATION_KEY"], os.environ["WILL_PCO_API_SECRET"])
 attachment_list = []
+
+
+def get_for_date(team, plan_date):
+    print('Looking up the team: ', team)
+    cal = parsedatetime.Calendar()
+    now_hour, now_minute = datetime.now().hour, datetime.now().minute
+    plan_date, parse_status = cal.parse(plan_date)
+    plan_date = datetime(*plan_date[:6]).astimezone().astimezone(pytz.utc)
+    is_specific = False
+    start_time = datetime(month=plan_date.month, day=plan_date.day, year=plan_date.year)
+    if plan_date.hour != now_hour or plan_date.minute != now_minute:
+        # parsedatetime by default creates a datetime matching the current hour and minute if not provided
+        # is_specific is True if the parsed string contains a specific time, e.g. "Sunday at 9AM"
+        is_specific = True
+        start_time = datetime(month=plan_date.month,
+                              day=plan_date.day,
+                              year=plan_date.year,
+                              hour=plan_date.hour,
+                              minute=plan_date.minute)
+    team_members = {
+        'confirmed': [],
+        'unconfirmed': [],
+        'declined': [],
+    }
+    for t in pco.services.teams.list(where={'name': team}, include='people'):
+        for member in t.rel.people.list():
+            for plan_person in member.rel.plan_people.list():
+                for plan_time in plan_person.rel.plan_times.list():
+                    starts_at = datetime.strptime(plan_time.starts_at, '%Y-%m-%dT%H:%M:%SZ')
+                    if starts_at == start_time:
+                        if plan_person.status in ('C', 'Confirmed'):
+                            team_members['confirmed'].append(plan_person)
+                        elif plan_person.status in ('U', 'Unconfirmed'):
+                            team_members['unconfirmed'].append(plan_person)
+    if is_specific:
+        plan_date = plan_date.astimezone()  # Convert to local timezone
+        plan_date_format = plan_date.strftime('%m-%d-%Y at %I:%M%p')
+    else:
+        plan_date_format = plan_date.strftime('%m-%d-%Y')
+    if len(team_members['confirmed']) + len(team_members['unconfirmed']) == 0:
+        msg = "Could not find any team members scheduled for that date ({}).".format(plan_date_format)
+    else:
+        msg = '{} team members scheduled for *{}*:'.format(team.capitalize(), plan_date_format)
+        for status in ['confirmed', 'unconfirmed']:
+            msg += '\n\n{}:'.format(status.capitalize())
+            for plan_person in team_members[status]:
+                msg += '\n- {}'.format(plan_person.name)
+    attachment_list.append(msg_attachment.
+                           SlackAttachment(fallback=msg, text=msg))
+    return attachment_list
 
 
 def get(team):
@@ -12,27 +64,26 @@ def get(team):
     print("Looking up the team: ", team)
     msg = ""
     if team:
-            for t in pco.services.teams.list(where={'name': team}, include='people'):
-                service = t.rel.service_type.get().id
-                team_id = t.id
-                msg += "*" + pco.services.service_types.get(service).name
-                msg += " " + t.name + ":*"
-                for id_number in t.rel.people.list():
-                    msg += "\n" + " ".join([pco.services.people.get(id_number.id).first_name,
-                                            pco.services.people.get(id_number.id).last_name])
-                attachment_list.append(msg_attachment.SlackAttachment(fallback=msg, pco='services',
-                                                                      text=msg, button_text="Open in Services",
-                                                                      button_url="/".join(["https://services."
-                                                                                           "planningcenteronline.com/"
-                                                                                           "service_types",
-                                                                                           service, "teams", team_id,
-                                                                                           "positions"])))
-                msg = ""
+        for t in pco.services.teams.list(where={'name': team}, include='people'):
+            service = t.rel.service_type.get().id
+            team_id = t.id
+            msg += "*" + pco.services.service_types.get(service).name
+            msg += " " + t.name + ":*"
+            for id_number in t.rel.people.list():
+                msg += "\n" + " ".join([pco.services.people.get(id_number.id).first_name,
+                                        pco.services.people.get(id_number.id).last_name])
+            attachment_list.append(msg_attachment.SlackAttachment(fallback=msg, pco='services',
+                                                                  text=msg, button_text="Open in Services",
+                                                                  button_url="/".join(["https://services."
+                                                                                       "planningcenteronline.com/"
+                                                                                       "service_types",
+                                                                                       service, "teams", team_id,
+                                                                                       "positions"])))
+            msg = ""
     else:
         print("else")
         msg = "*Planning Center Services Teams:*"
         for team in pco.services.teams.list():
-
             msg += "\n" + team.name
         attachment_list.append(msg_attachment.SlackAttachment(fallback=msg, pco='services',
                                                               text=msg, button_text="Open in Services",
@@ -45,12 +96,12 @@ def get(team):
 
 def get_team_assignments(team):
     if team:
-            for t in pco.services.teams.list(where={'name': team}, include='people'):
-                for member in t.rel.people.list():
-                    print(pco.services.people.get(member.id).first_name)
-                    print(pco.services.people.get(member.id).last_name)
-                    for plan_people in member.rel.plan_people.list():
-                        print(plan_people.team_position_name)
+        for t in pco.services.teams.list(where={'name': team}, include='people'):
+            for member in t.rel.people.list():
+                print(pco.services.people.get(member.id).first_name)
+                print(pco.services.people.get(member.id).last_name)
+                for plan_people in member.rel.plan_people.list():
+                    print(plan_people.team_position_name)
 
     else:
         print("No team given")


### PR DESCRIPTION
For issue #105 

I added a function in pcoservices to respond to queries of the form:

> who is scheduled on the <team name> team <when>?

e.g. 
> "who is scheduled on the Downtown Band team on Sunday at 6PM?

If you specify a time, it will try to find the team for that precise time--if you do not, it will simply try to match the team for the day provided.

I tried to mimic other files in form (and I removed some unnecessary whitespace).