### PR TITLE
Made the RegEx expression more flexible and added times for vague dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ If no app name is provided it will list all the apps you can access.
 * ```Show the set list for *[Any future service date]*```
 * ```Show the set list for *[Any future service date]*```
 * ```What is the arrangement for [Any Song]?```
-* ```Who is scheduled on the *[Any Services team]* team on *[Any future day/date]* at *[6PM]*?```
+* ```Who is *[serving|scheduled]* *[on|for]* the *[Any Services team]* team *[Any future day/date/time]*?```
+    * Examples:
+    * "Who is serving on the band team on Sunday at 10a?"
+    * "Who is scheduled for the Downtown Band team today?"
+* ```[!serving|!scheduled] *[Any Services team]* *[Any future day/date/time]*```
+    * Note: for teams with more than one word in the name, wrap the team name in quotes. E.g. `!serving 'Downtown Band' Sunday`
+
 
 If you specify a time, it will try to find the team for that precise service time—if you do not, it will simply try to match the team for the day provided.
 

--- a/plugins/pco/pcoservices.py
+++ b/plugins/pco/pcoservices.py
@@ -67,16 +67,24 @@ class PcoServicesPlugin(WillPlugin):
         else:
             self.say("", message=message, attachments=attachment, channel=wl_chan_id(self))
 
-    @respond_to("(who is scheduled on the )(?P<pco_team>[\w\s]+) team (?P<pco_date>.*?(?=(?:\'|\?)|$))\??")
+    @respond_to("who is (serving|scheduled) (on|for)( the)? (?P<pco_team>[\w ]+) team\s?(?P<pco_date>.*?(?=(?:\'|\?)|$))\??")
     def pco_team_schedule_lookup(self, message, pco_team, pco_date):
         """Lookup a [team] and display its confirmed and unconfirmed members for a given date"""
         pco_team = pco_team.strip()
         self.reply("Hold on; I'll look up that team's schedule for you.")
+        if pco_date.strip() == '':
+            pco_date = 'today'
         attachments = teams.get_for_date(pco_team, pco_date)
         attachment = []
         for returned_attachment in attachments:
             attachment += returned_attachment.slack()
         self.say("", message=message, attachments=attachment, channel=wl_chan_id(self))
+
+    @respond_to("(!serving|!scheduled) ((\"|\')(?P<pco_team>[\w ]+)(\"|\')|(?P<pco_team_unquoted>[\w]+)) (?P<pco_date>.*?(?=(?:\'|\?)|$))")
+    def pco_team_schedule_lookup_command(self, message, pco_team, pco_team_unquoted, pco_date):
+        if pco_team.strip() == '':
+            pco_team = pco_team_unquoted
+        self.pco_team_schedule_lookup(message, pco_team, pco_date)
 
 
 # Test your setup by running this file.

--- a/plugins/pco/teams.py
+++ b/plugins/pco/teams.py
@@ -9,15 +9,16 @@ pco = pypco.PCO(os.environ["WILL_PCO_APPLICATION_KEY"], os.environ["WILL_PCO_API
 attachment_list = []
 
 
-def get_for_date(team, plan_date):
+def get_for_date(team, date_expression):
     print('Looking up the team: ', team)
     cal = parsedatetime.Calendar()
-    now_hour, now_minute = datetime.now().hour, datetime.now().minute
-    plan_date, parse_status = cal.parse(plan_date)
+    now = datetime.now().astimezone().astimezone(pytz.utc)
+    now_hour, now_minute = now.hour, now.minute
+    plan_date, parse_status = cal.parse(date_expression)
     plan_date = datetime(*plan_date[:6]).astimezone().astimezone(pytz.utc)
     is_specific = False
     start_time = datetime(month=plan_date.month, day=plan_date.day, year=plan_date.year)
-    if plan_date.hour != now_hour or plan_date.minute != now_minute:
+    if date_expression != 'today' and (plan_date.hour != now_hour or plan_date.minute != now_minute):
         # parsedatetime by default creates a datetime matching the current hour and minute if not provided
         # is_specific is True if the parsed string contains a specific time, e.g. "Sunday at 9AM"
         is_specific = True
@@ -26,21 +27,22 @@ def get_for_date(team, plan_date):
                               year=plan_date.year,
                               hour=plan_date.hour,
                               minute=plan_date.minute)
+    start_time = pytz.utc.localize(start_time)
     team_members = {
         'confirmed': [],
         'unconfirmed': [],
-        'declined': [],
     }
     for t in pco.services.teams.list(where={'name': team}, include='people'):
         for member in t.rel.people.list():
             for plan_person in member.rel.plan_people.list():
                 for plan_time in plan_person.rel.plan_times.list():
-                    starts_at = datetime.strptime(plan_time.starts_at, '%Y-%m-%dT%H:%M:%SZ')
-                    if starts_at == start_time:
+                    starts_at = pytz.utc.localize(datetime.strptime(plan_time.starts_at, '%Y-%m-%dT%H:%M:%SZ'))
+                    hour_format = starts_at.astimezone().strftime('%I:%M%p')
+                    if dates_match(starts_at, start_time, is_specific):
                         if plan_person.status in ('C', 'Confirmed'):
-                            team_members['confirmed'].append(plan_person)
+                            team_members['confirmed'].append((plan_person, hour_format))
                         elif plan_person.status in ('U', 'Unconfirmed'):
-                            team_members['unconfirmed'].append(plan_person)
+                            team_members['unconfirmed'].append((plan_person, hour_format))
     if is_specific:
         plan_date = plan_date.astimezone()  # Convert to local timezone
         plan_date_format = plan_date.strftime('%m-%d-%Y at %I:%M%p')
@@ -52,8 +54,10 @@ def get_for_date(team, plan_date):
         msg = '{} team members scheduled for *{}*:'.format(team.capitalize(), plan_date_format)
         for status in ['confirmed', 'unconfirmed']:
             msg += '\n\n{}:'.format(status.capitalize())
-            for plan_person in team_members[status]:
-                msg += '\n- {}'.format(plan_person.name)
+            for plan_person_tuple in team_members[status]:
+                msg += '\n- {}'.format(plan_person_tuple[0].name)
+                if not is_specific:
+                    msg += ' ({})'.format(plan_person_tuple[1])
     attachment_list.append(msg_attachment.
                            SlackAttachment(fallback=msg, text=msg))
     return attachment_list
@@ -107,6 +111,13 @@ def get_team_assignments(team):
         print("No team given")
 
     return
+
+
+def dates_match(date_one, date_two, is_specific):
+    if is_specific:
+        return date_one == date_two
+    else:
+        return date_one.day == date_two.day and date_one.month == date_two.month and date_one.year == date_two.year
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I added the following features:

- I made the RegEx expression for fetching team schedules more flexible. They now accept queries of the form `Who is *[serving|scheduled]* *[on|for]* the *[Any Services team]* team *[Any future day/date/time]*?`
- I added more command-like invocations (`!serving` and `!scheduled`). **Note:** if supplying a team name with multiple words, you must wrap the name in quotes.
- I enhanced the response to these queries. Now, if you make a vague request (i.e. "who is serving on the band team on Sunday"), the bot responds with times attached to each team member to clarify when in the day they are serving.

So, in response to "who is serving on the Downtown Band team on Sunday?"

The bot responds with:
```
Downtown band team members scheduled for *04-07-2019*:

Confirmed:
- DevTest TestOne (06:00PM)

Unconfirmed:
- Caleb Dinsmore (06:00PM)
- Caleb Dinsmore (10:00AM)
- DevTest TestOne (10:00AM)
```